### PR TITLE
feat: update diff tool from cmp to diff

### DIFF
--- a/.github/actions/aml-env-ensure/action.yaml
+++ b/.github/actions/aml-env-ensure/action.yaml
@@ -45,7 +45,7 @@ runs:
             if [[ $(az ml environment show --name $ENV_NAME --workspace-name ${{ inputs.workspaceName }} --resource-group ${{ inputs.resourceGroup }} --version $ENV_VERSION) ]]; then
               echo "::debug::Verifying environment specification and checking for differences with given"
               az ml environment show --name $ENV_NAME --workspace-name ${{ inputs.workspaceName }} --resource-group ${{ inputs.resourceGroup }} --version $ENV_VERSION | jq ".conda_file | del(.name)" | yq -y > conda.yml
-              if cmp -s conda.yml $ENV_FOLDER/$ENV_CONDA_FILE; then
+              if diff -w -B conda.yml $ENV_FOLDER/$ENV_CONDA_FILE; then
                 echo "::debug::Environments validation passed"
               else
                 echo "::error file=$ENV_FILE::Environment file definition doesn't match the one registered. Please increase version to get it created"


### PR DESCRIPTION
This PR addresses a bug where conda dependency files that differed only by white space were causing the cmp tool to say the files were different.
Updating the diff tool to use diff, which has the following flags to help with this issue:
-w, --ignore-all-space ignore all white space
-B, --ignore-blank-lines ignore changes where lines are all blank
Tested these changes by manually triggering this workflow run:
https://github.com/csu-devsquad-latam/trunkbased-mlops/actions/runs/2545603342